### PR TITLE
chore: use non-deprecated bubbletea method

### DIFF
--- a/cmd/aks-node-viewer/main.go
+++ b/cmd/aks-node-viewer/main.go
@@ -94,7 +94,7 @@ func main() {
 		pricing:      pprov,
 	}
 	startMonitor(ctx, monitorSettings)
-	if err := tea.NewProgram(m, tea.WithAltScreen()).Start(); err != nil {
+	if _, err := tea.NewProgram(m, tea.WithAltScreen()).Run(); err != nil {
 		log.Fatalf("error running tea: %s", err)
 	}
 	cancel()


### PR DESCRIPTION
This is a housekeeping PR to update a downstream lib method call to use an updated, non-deprecated interface.

Equivalent eks-node-viewer change: https://github.com/awslabs/eks-node-viewer/pull/151/files#diff-e0dd89780fa182ab8a6254cca1ad099e1919222318da9d4239889e56d3886788R103