### PR TITLE
Use on-demand pricing if no Karpenter labels are found

### DIFF
--- a/pkg/model/node.go
+++ b/pkg/model/node.go
@@ -196,5 +196,9 @@ func (n *Node) UpdatePrice(pricing *pricing.Provider) {
 		if price, ok := pricing.SpotPrice(n.InstanceType()); ok {
 			n.Price = price
 		}
+	} else {
+		if price, ok := pricing.OnDemandPrice(n.InstanceType()); ok {
+			n.Price = price
+		}
 	}
 }

--- a/pkg/model/node.go
+++ b/pkg/model/node.go
@@ -196,6 +196,7 @@ func (n *Node) UpdatePrice(pricing *pricing.Provider) {
 		if price, ok := pricing.SpotPrice(n.InstanceType()); ok {
 			n.Price = price
 		}
+	// Use on-demand prices if no Karpenter label is found
 	} else {
 		if price, ok := pricing.OnDemandPrice(n.InstanceType()); ok {
 			n.Price = price


### PR DESCRIPTION
Fallback to on-demand pricing for node when it doesn't contain karpenter.sh/capacity-type label. It will allow to use this tool on AKS clusters without Karpenter.